### PR TITLE
Support for Nette 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.0
   - 7.1
 
 install:
@@ -18,7 +17,7 @@ script:
 
 after_success:
   - >
-    if [ $TRAVIS_PHP_VERSION == "7.0" ]; then
+    if [ $TRAVIS_PHP_VERSION == "7.1" ]; then
     wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar
     && php ./coveralls.phar --verbose
     || true; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ cache:
 
 php:
   - 7.1
-
+  - 7.2
+  - 7.3
+  - 7.4
 install:
   - composer install --no-interaction --prefer-dist
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Proxying certain Nette services is automaticaly disabled due to [known limitatio
 
 ### Pre-generating proxies
 
-Proxy generation causes I/O operations and uses a lot of reflection, so it is handy to have them pre-generated before the application starts. For this, install [Kdyby/Console](https://github.com/kdyby/console) and run:
+Proxy generation causes I/O operations and uses a lot of reflection, so it is handy to have them pre-generated before the application starts. For this, install Symfony/Console integration (such as [Contributte/Console](https://github.com/contributte/console)) and run:
 
 ```sh
 php www/index.php lookyman:nette-proxy:generate

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     }
   ],
   "require": {
+    "php": ">=7.1",
     "ocramius/proxy-manager": "^2.0",
     "nette/di": "^2.4",
     "nette/php-generator": "^2.6|^3.0"

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,13 @@
   "require": {
     "php": ">=7.1",
     "ocramius/proxy-manager": "^2.0",
-    "nette/di": "^2.4",
-    "nette/php-generator": "^2.6|^3.0"
+    "nette/di": "^3.0.1",
+    "nette/php-generator": "^3.2",
+    "symfony/console": "4.0 || ^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6",
-    "nette/bootstrap": "^2.4",
-    "kdyby/console": "^2.6"
-  },
-  "suggest": {
-    "kdyby/console": "For pre-generating proxies via a command"
+    "nette/bootstrap": "^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "ocramius/proxy-manager": "^2.0",
+    "ocramius/proxy-manager": "^2.1",
     "nette/di": "^3.0.1",
     "nette/php-generator": "^3.2",
     "symfony/console": "4.0 || ^5.0"

--- a/src/Console/GenerateProxiesCommand.php
+++ b/src/Console/GenerateProxiesCommand.php
@@ -12,7 +12,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateProxiesCommand extends Command
 {
-	protected function configure()
+    /** @var Container */
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        parent::__construct();
+        $this->container = $container;
+    }
+
+    protected function configure()
 	{
 		$this->setName('lookyman:nette-proxy:generate')
 			->setDescription('Generate proxies for lazy services')
@@ -23,13 +32,13 @@ class GenerateProxiesCommand extends Command
 	{
 		$debug = $input->getOption('debug');
 
-		/** @var Container $container */
-		$container = $this->getHelper('container')->getContainer();
-		foreach (array_keys($container->findByTag(ProxyExtension::TAG_LAZY)) as $name) {
-			$container->getService($name);
+		foreach (array_keys($this->container->findByTag(ProxyExtension::TAG_LAZY)) as $name) {
+			$this->container->getService($name);
 			if ($debug) {
 				$output->writeln(sprintf('Proxy for service %s generated', $name));
 			}
 		}
+
+		return 0;
 	}
 }

--- a/src/DI/ProxyExtension.php
+++ b/src/DI/ProxyExtension.php
@@ -6,8 +6,8 @@ namespace Lookyman\Nette\Proxy\DI;
 use Lookyman\Nette\Proxy\Console\GenerateProxiesCommand;
 use Nette\DI\CompilerExtension;
 use Nette\DI\Container;
+use Nette\DI\Definitions\Statement;
 use Nette\DI\Helpers;
-use Nette\DI\Statement;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Closure;
 use Nette\Utils\Validators;
@@ -55,13 +55,13 @@ class ProxyExtension extends CompilerExtension
 
 		// generator strategy
 		$builder->addDefinition($this->prefix('generatorStrategy'))
-			->setClass(FileWriterGeneratorStrategy::class, [new Statement(FileLocator::class, [$config['proxyDir']])])
+			->setFactory(FileWriterGeneratorStrategy::class, [new Statement(FileLocator::class, [$config['proxyDir']])])
 			->setAutowired(false)
 			->addTag(self::TAG_LAZY, false);
 
 		// configuration
 		$builder->addDefinition($this->prefix('configuration'))
-			->setClass(Configuration::class)
+			->setFactory(Configuration::class)
 			->addSetup('setProxiesTargetDir', [$config['proxyDir']])
 			->addSetup('setGeneratorStrategy', [$this->prefix('@generatorStrategy')])
 			->setAutowired(false)
@@ -69,18 +69,12 @@ class ProxyExtension extends CompilerExtension
 
 		// proxy factory
 		$builder->addDefinition($this->prefix('lazyLoadingValueHolderFactory'))
-			->setClass(LazyLoadingValueHolderFactory::class, [$this->prefix('@configuration')])
+			->setFactory(LazyLoadingValueHolderFactory::class, [$this->prefix('@configuration')])
 			->setAutowired(false)
 			->addTag(self::TAG_LAZY, false);
 
-		// command
-		/** @var \Kdyby\Console\DI\ConsoleExtension $extension */
-		foreach ($this->compiler->getExtensions('Kdyby\Console\DI\ConsoleExtension') as $extension) {
-			$builder->addDefinition($this->prefix('generateProxiesCommand'))
-				->setClass(GenerateProxiesCommand::class)
-				->addTag($extension::TAG_COMMAND);
-			break;
-		}
+        $builder->addDefinition($this->prefix('generateProxiesCommand'))
+            ->setFactory(GenerateProxiesCommand::class);
 	}
 
 	public function beforeCompile()

--- a/tests/Console/GenerateProxiesCommandTest.php
+++ b/tests/Console/GenerateProxiesCommandTest.php
@@ -3,9 +3,10 @@ declare(strict_types=1);
 
 namespace Lookyman\Nette\Proxy\Tests\Console;
 
-use Kdyby\Console\Application;
+use Lookyman\Nette\Proxy\Console\GenerateProxiesCommand;
 use Lookyman\Nette\Proxy\Tests\Helpers;
 use Nette\Configurator;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class GenerateProxiesCommandTest extends \PHPUnit_Framework_TestCase
@@ -23,9 +24,11 @@ class GenerateProxiesCommandTest extends \PHPUnit_Framework_TestCase
 			->createContainer();
 		$container->initialize();
 
-		/** @var Application $application */
-		$application = $container->getByType(Application::class);
-		$command = $application->find('lookyman:nette-proxy:generate');
+		$command = $container->getByType(GenerateProxiesCommand::class);
+
+		$application = new Application();
+		$application->add($command);
+
 		$tester = new CommandTester($command);
 		$tester->execute([
 			'command' => $command->getName(),

--- a/tests/DI/ProxyExtensionTest.php
+++ b/tests/DI/ProxyExtensionTest.php
@@ -22,7 +22,6 @@ class ProxyExtensionTest extends \PHPUnit_Framework_TestCase
 			->setDebugMode(true)
 			->addConfig(__DIR__ . '/../config/config.neon')
 			->createContainer();
-		$container->initialize();
 
 		/** @var Service1 $service1 */
 		$service1 = $container->getByType(Service1::class);

--- a/tests/config/config.neon
+++ b/tests/config/config.neon
@@ -1,8 +1,7 @@
 di:
-	debugger: off
+	debugger: false
 
 extensions:
-	console: Kdyby\Console\DI\ConsoleExtension
 	proxy: Lookyman\Nette\Proxy\DI\ProxyExtension
 
 proxy:


### PR DESCRIPTION
I added support for `nette/di` `^3.0`

There are several other changes than just dependency bump.

- I added PHP 7.1 as minimal supported version (7.1 is minimal version [supported by nette/di 3.0 anyway](https://github.com/nette/di/blob/v3.0.0/composer.json#L18))
- I bumped minimal `ocramius/proxy-manager` to 2.1.0, because it's the first version that supports PHP 7.1
- `GenerateProxiesCommand` is now always registered, because there is no `kdyby/console` version that supports `nette/di` 3.0 and registered service is not tagged with kdyby-specific tag. Once (and if) there will be version that supports `nette/di` 3.0, this tag can be reintroduced.
- `symfony/console` is now direct dependency - this allows us to always register command (mentioned above) in container - there is no implicit dependency on console Application - it does not have to be registered and everything will work anyway.
